### PR TITLE
make it possible to mixin into plain object

### DIFF
--- a/microevent-debug.js
+++ b/microevent-debug.js
@@ -37,7 +37,11 @@ MicroEvent.prototype	= {
 MicroEvent.mixin	= function(destObject){
 	var props	= ['bind', 'unbind', 'trigger'];
 	for(var i = 0; i < props.length; i ++){
-		destObject.prototype[props[i]]	= MicroEvent.prototype[props[i]];
+		if( typeof destObject === 'function' ){
+			destObject.prototype[props[i]]	= MicroEvent.prototype[props[i]];
+		}else{
+			destObject[props[i]] = MicroEvent.prototype[props[i]];
+		}
 	}
 }
 

--- a/microevent.js
+++ b/microevent.js
@@ -40,7 +40,11 @@ MicroEvent.prototype	= {
 MicroEvent.mixin	= function(destObject){
 	var props	= ['bind', 'unbind', 'trigger'];
 	for(var i = 0; i < props.length; i ++){
-		destObject.prototype[props[i]]	= MicroEvent.prototype[props[i]];
+		if( typeof destObject === 'function' ){
+			destObject.prototype[props[i]]	= MicroEvent.prototype[props[i]];
+		}else{
+			destObject[props[i]] = MicroEvent.prototype[props[i]];
+		}
 	}
 }
 

--- a/tests/bad.js
+++ b/tests/bad.js
@@ -10,3 +10,8 @@ console.log("")
 
 f.trigger("blerg", "yes")
 b.trigger("blerg", "no")
+
+c = {}
+MicroEvent.mixin(c)
+c.bind('foo',function(bar){console.log(bar)})
+c.trigger('foo','bar')


### PR DESCRIPTION
currently, the mixin only works for "class" aka functions,

but in JS, we sometimes use plain object directly, like this:

```
var o = {}
MicroEvent.mixin(o)
o.bind('any',function(){//event code})
```

please consider to merge
