### PR TITLE
Jasmine specs for MicroEvent

### DIFF
--- a/spec/MicroEventSpec.js
+++ b/spec/MicroEventSpec.js
@@ -1,0 +1,115 @@
+describe("MicroEvent", function() {
+	var micro_event;
+	var event_funcs;
+
+	beforeEach(function() {
+		micro_event = new MicroEvent(); 
+
+		event_funcs = {
+			foo: function() {},
+			bar: function() {},
+			baz: function() {}
+		};
+		spyOn(event_funcs, 'foo');
+		spyOn(event_funcs, 'bar');
+		spyOn(event_funcs, 'baz');
+
+	});
+
+	it("binds a single function to an event", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.trigger('event_one');
+
+		expect(event_funcs.foo).toHaveBeenCalled();
+		expect(event_funcs.foo.calls.length).toEqual(1);
+	});
+
+	it("passes arguments to a bound function", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.trigger('event_one', 1, 2);
+
+		expect(event_funcs.foo).toHaveBeenCalledWith(1, 2);
+	});
+
+	it("binds several functions to one event", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.bind('event_one', event_funcs.bar);
+		micro_event.bind('event_one', event_funcs.baz);
+
+		micro_event.trigger('event_one');
+
+		expect(event_funcs.foo).toHaveBeenCalled();
+		expect(event_funcs.foo.calls.length).toEqual(1);
+
+		expect(event_funcs.bar).toHaveBeenCalled();
+		expect(event_funcs.bar.calls.length).toEqual(1);
+
+		expect(event_funcs.baz).toHaveBeenCalled();
+		expect(event_funcs.baz.calls.length).toEqual(1);
+	});
+
+	it("passes arguments to all functions bound to the same event", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.bind('event_one', event_funcs.bar);
+		micro_event.bind('event_one', event_funcs.baz);
+
+		micro_event.trigger('event_one', 1, 2);
+
+		expect(event_funcs.foo).toHaveBeenCalledWith(1, 2);
+		expect(event_funcs.bar).toHaveBeenCalledWith(1, 2);
+		expect(event_funcs.baz).toHaveBeenCalledWith(1, 2);
+	});
+
+	it("binds functions to several different events", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.bind('event_two', event_funcs.bar);
+		micro_event.bind('event_three', event_funcs.baz);
+
+		micro_event.trigger('event_one');
+		micro_event.trigger('event_two');
+		micro_event.trigger('event_three');
+
+		expect(event_funcs.foo).toHaveBeenCalled();
+		expect(event_funcs.foo.calls.length).toEqual(1);
+
+		expect(event_funcs.bar).toHaveBeenCalled();
+		expect(event_funcs.bar.calls.length).toEqual(1);
+
+		expect(event_funcs.baz).toHaveBeenCalled();
+		expect(event_funcs.baz.calls.length).toEqual(1);
+	});
+
+	it("unbinds a function from an event", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.bind('event_one', event_funcs.bar);
+
+		micro_event.unbind('event_one', event_funcs.foo);
+
+		micro_event.trigger('event_one');
+
+		expect(event_funcs.foo).not.toHaveBeenCalled();
+
+		expect(event_funcs.bar).toHaveBeenCalled();
+		expect(event_funcs.bar.calls.length).toEqual(1);
+	});
+
+	it("keeps working when triggering unknown event", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.bind('event_two', event_funcs.bar);
+
+		micro_event.trigger('unknown_event');
+
+		expect(event_funcs.foo).not.toHaveBeenCalled();
+		expect(event_funcs.bar).not.toHaveBeenCalled();
+	});
+
+	it("keeps working when unbinding unknown event", function() {
+		micro_event.bind('event_one', event_funcs.foo);
+		micro_event.unbind('unknown_event');
+
+		micro_event.trigger('event_one');
+
+		expect(event_funcs.foo).toHaveBeenCalled();
+	});
+});
+

--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+	"http://www.w3.org/TR/html4/loose.dtd">
+<html>
+<head>
+	<title>Conference Schedule - Jasmine Spec Runner</title>
+
+	<link rel="stylesheet" type="text/css" href="../jasmine/lib/jasmine-1.3.0/jasmine.css">
+	<script type="text/javascript" src="../jasmine/lib/jasmine-1.3.0/jasmine.js"></script>
+	<script type="text/javascript" src="../jasmine/lib/jasmine-1.3.0/jasmine-html.js"></script>
+
+	<!-- include source files here... -->
+	<script type="text/javascript" src="../microevent.js"></script>
+
+	<!-- include spec files here... -->
+	<script type="text/javascript" src="MicroEventSpec.js"></script>
+
+	<script type="text/javascript">
+		(function() {
+			var jasmineEnv = jasmine.getEnv();
+			jasmineEnv.updateInterval = 1000;
+
+			var htmlReporter = new jasmine.HtmlReporter();
+
+			jasmineEnv.addReporter(htmlReporter);
+
+			jasmineEnv.specFilter = function(spec) {
+				return htmlReporter.specFilter(spec);
+			};
+
+			var currentWindowOnload = window.onload;
+
+			window.onload = function() {
+				if (currentWindowOnload) {
+					currentWindowOnload();
+				}
+				execJasmine();
+			};
+
+			function execJasmine() {
+				jasmineEnv.execute();
+			}
+
+		})();
+	</script>
+
+</head>
+
+<body>
+</body>
+</html>


### PR DESCRIPTION
Here are Jasmine specs (http://pivotal.github.io/jasmine/) for MicroEvent

I kinda wrote them by accident - I actually wanted to contribute to some friends' project by writing some tests and picked MicroEvent as the next target, not realizing that MicroEvent is actually an external library. (https://github.com/glaubinix/conference-schedule/pull/15)
Not sure what I was thinking but, well, whatever - here I am with the specs. :D

If you want to run them, simply create a new dir "jasmine", download jasmine (https://github.com/downloads/pivotal/jasmine/jasmine-standalone-1.3.0.zip) and unzip it into the jasmine-dir.
Then simply open spec/SpecRunner.html in a browser and the specs will be executed.
If you decide to merge my pull request, then I'd suggest to get Jasmine installed by npm. i would do all work necessary for that, as well.
