### PR TITLE
do not rely on indexOf: it wont be there for IElt9

### DIFF
--- a/microevent-debug.js
+++ b/microevent-debug.js
@@ -15,8 +15,13 @@ MicroEvent.prototype	= {
 		console.assert(typeof fct === 'function');
 		this._events = this._events || {};		
 		if( event in this._events === false  )	return;
-		console.assert(this._events[event].indexOf(fct) !== -1);
-		this._events[event].splice(this._events[event].indexOf(fct), 1);
+		length = this._events[event].length;
+		for (index = 0; index < length; index++) {
+			if (this._events[event][index] === fct)	break;
+		}
+		console.assert(index < length);
+		if (index == length)	return;
+		this._events[event].splice(index, 1);
 	},
 	trigger	: function(event /* , args... */){
 		this._events = this._events || {};		

--- a/microevent.js
+++ b/microevent.js
@@ -3,7 +3,7 @@
  * 
  * - pure javascript - server compatible, browser compatible
  * - dont rely on the browser doms
- * - super simple - you get it immediatly, no mistery, no magic involved
+ * - super simple - you get it immediately, no mystery, no magic involved
  *
  * - create a MicroEventDebug with goodies to debug
  *   - make it safer to use
@@ -18,8 +18,13 @@ MicroEvent.prototype	= {
 	},
 	unbind	: function(event, fct){
 		this._events = this._events || {};
-		if( event in this._events === false  )	return;
-		this._events[event].splice(this._events[event].indexOf(fct), 1);
+		if (event in this._events === false)	return;
+		length = this._events[event].length;
+		for (index = 0; index < length; index++) {
+			if (this._events[event][index] === fct)	break;
+		}
+		if (index == length)	return;
+		this._events[event].splice(index, 1);
 	},
 	trigger	: function(event /* , args... */){
 		this._events = this._events || {};

--- a/tests/bad.js
+++ b/tests/bad.js
@@ -13,5 +13,14 @@ b.trigger("blerg", "no")
 
 c = {}
 MicroEvent.mixin(c)
-c.bind('foo',function(bar){console.log(bar)})
+fooFunc = function(bar){console.log(bar)};
+c.bind('foo', fooFunc)
+
+
+console.log("")
+console.log("You should see 'bar' once only:");
+console.log("")
 c.trigger('foo','bar')
+c.unbind('foo', fooFunc);
+c.trigger('foo', 'bar');
+


### PR DESCRIPTION
the Array class in IE<9 does not have indexOf.
considering how small this useful script is, and how simple the requirement, I'd rather an inline implementation than relying on a shim or another script.
